### PR TITLE
[WIP]Item detail display function 

### DIFF
--- a/app/assets/stylesheets/purchases.scss
+++ b/app/assets/stylesheets/purchases.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the purchases controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,4 @@
 class ItemsController < ApplicationController
-
   before_action :set_item, only: [:show]
 
   def index
@@ -21,7 +20,7 @@ class ItemsController < ApplicationController
 
   def show
   end
-    
+
   def set_item
     @item = Item.find(params[:id])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,7 @@
 class ItemsController < ApplicationController
+
+  before_action :set_item, only: [:show]
+
   def index
     @items = Item.all.order('created_at DESC')
   end
@@ -14,6 +17,13 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+  end
+    
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,8 @@ class ItemsController < ApplicationController
       :status_id,
       :postage_pay_id,
       :shipping_area_id,
-      :days_until_shipping_id
-    )
+      :days_until_shipping_id,
+      :user_id
+    ).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,0 +1,3 @@
+class PurchasesController < ApplicationController
+  @buyer = Purchase.find(params[:id])
+end

--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,0 +1,2 @@
+module PurchasesHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,6 +23,7 @@ class Item < ApplicationRecord
     assoc.validates :postage_pay_id
     assoc.validates :shipping_area_id
     assoc.validates :days_until_shipping_id
+    assoc.validates :user
   end
 
   with_options numericality: { other_than: 1 } do

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,9 @@ class Item < ApplicationRecord
   belongs_to_active_hash :shipping_area
   belongs_to_active_hash :days_until_shipping
 
+  belongs_to :user
+  has_one :purchase
+
   has_one_attached :image
   validates_presence_of :image
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,2 @@
+class Purchase < ApplicationRecord
+end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,2 +1,4 @@
 class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :items
+  has_many :purchases
+
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,100}\z/i, message: 'は半角英数字混合で入力してください。' }
   validates :password_confirmation, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{6,100}\z/i, message: 'は半角英数字混合で入力してください。' }
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% @items.each do |item| %>
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,9 +133,12 @@
             <%= image_tag item.image, class: "item-img" %>
 
             <%# 商品が売れていればsold outの表示 %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
+            <% if @buyer.nil? %>
+            <% else%>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+            <% end %>
             <%# //商品が売れていればsold outの表示 %>
 
           </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,11 +24,11 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,12 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
+      <% if @buyer.nil? %>
+      <% else%>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
@@ -30,7 +33,10 @@
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% else %>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
@@ -42,27 +48,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage_pay.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20200704081944_create_items.rb
+++ b/db/migrate/20200704081944_create_items.rb
@@ -11,6 +11,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :postage_pay_id, null: false
       t.integer :shipping_area_id, null: false
       t.integer :days_until_shipping_id, null: false
+      t.references :user, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20200708060425_create_purchases.rb
+++ b/db/migrate/20200708060425_create_purchases.rb
@@ -1,0 +1,9 @@
+class CreatePurchases < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchases do |t|
+      t.references :user_id, null: false, foreign_key: true
+      t.references :item_id, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200708060425_create_purchases.rb
+++ b/db/migrate/20200708060425_create_purchases.rb
@@ -1,8 +1,8 @@
 class CreatePurchases < ActiveRecord::Migration[6.0]
   def change
     create_table :purchases do |t|
-      t.references :user_id, null: false, foreign_key: true
-      t.references :item_id, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_06_091257) do
+ActiveRecord::Schema.define(version: 2020_07_08_060425) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -44,8 +44,19 @@ ActiveRecord::Schema.define(version: 2020_07_06_091257) do
     t.integer "postage_pay_id", null: false
     t.integer "shipping_area_id", null: false
     t.integer "days_until_shipping_id", null: false
+    t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,4 +78,7 @@ ActiveRecord::Schema.define(version: 2020_07_06_091257) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "items", "users"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -13,5 +13,6 @@ FactoryBot.define do
     after(:build) do |item|
       item.image.attach(io: File.open(Rails.root.join('spec', 'factories', 'images', 'sample.jpg')), filename: 'sample.jpg')
     end
+    association :user
   end
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :purchase do
-    
   end
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchase do
+    
+  end
+end

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchasesHelper. For example:
+#
+# describe PurchasesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchasesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,102 +1,133 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
+  let(:user) { FactoryBot.create(:user) }
   describe '#create' do
+    before do
+      @item = build(:item)
+    end
+
     # 全てのカラムが存在すれば登録できること
     it 'is valid with all column' do
-      item = build(:item)
-      expect(item).to be_valid
+      # item = build(:item)
+      expect(@item).to be_valid
     end
 
     # imageが空であれば登録できないこと
     it 'is invalid without a image' do
-      item = build(:item)
-      item.image = nil
-      item.valid?
-      expect(item.errors[:image]).to include("can't be blank")
+      # item = build(:item)
+      @item.image = nil
+      @item.valid?
+      expect(@item.errors[:image]).to include("can't be blank")
     end
 
     # nameが空であれば登録できないこと
     it 'is invalid without a name' do
-      item = build(:item, name: nil)
-      item.valid?
-      expect(item.errors[:name]).to include("can't be blank")
+      # item = build(:item, name: nil)
+      @item.name = nil
+      @item.valid?
+      expect(@item.errors[:name]).to include("can't be blank")
     end
 
     # introductionが空であれば登録できないこと
     it 'is invalid without a introduction' do
-      item = build(:item, introduction: nil)
-      item.valid?
-      expect(item.errors[:introduction]).to include("can't be blank")
+      # item = build(:item, introduction: nil)
+      @item.introduction = nil
+      @item.valid?
+      expect(@item.errors[:introduction]).to include("can't be blank")
     end
 
     # priceが空であれば登録できないこと
     it 'is invalid without a price' do
-      item = build(:item, price: nil)
-      item.valid?
-      expect(item.errors[:price]).to include("can't be blank")
+      # item = build(:item, price: nil)
+      @item.price = nil
+      @item.valid?
+      expect(@item.errors[:price]).to include("can't be blank")
     end
 
     # sales_commissionが空であれば登録できないこと
     it 'is invalid without a sales_commission' do
-      item = build(:item, sales_commission: nil)
-      item.valid?
-      expect(item.errors[:sales_commission]).to include("can't be blank")
+      # item = build(:item, sales_commission: nil)
+      @item.sales_commission = nil
+      @item.valid?
+      expect(@item.errors[:sales_commission]).to include("can't be blank")
     end
 
     # sales_profitが空であれば登録できないこと
     it 'is invalid without a sales_profit' do
-      item = build(:item, sales_profit: nil)
-      item.valid?
-      expect(item.errors[:sales_profit]).to include("can't be blank")
+      # item = build(:item, sales_profit: nil)
+      @item.sales_profit = nil
+      @item.valid?
+      expect(@item.errors[:sales_profit]).to include("can't be blank")
     end
 
     # category_idが空であれば登録できないこと
     it 'is invalid without a category_id' do
-      item = build(:item, category_id: nil)
-      item.valid?
-      expect(item.errors[:category_id]).to include("can't be blank")
+      # item = build(:item, category_id: nil)
+      @item.category_id = nil
+      @item.valid?
+      expect(@item.errors[:category_id]).to include("can't be blank")
     end
 
     # status_idが空であれば登録できないこと
     it 'is invalid without a status_id' do
-      item = build(:item, status_id: nil)
-      item.valid?
-      expect(item.errors[:status_id]).to include("can't be blank")
+      # item = build(:item, status_id: nil)
+      @item.status_id = nil
+      @item.valid?
+      expect(@item.errors[:status_id]).to include("can't be blank")
     end
 
     # postage_pay_idが空であれば登録できないこと
     it 'is invalid without a postage_pay_id' do
-      item = build(:item, postage_pay_id: nil)
-      item.valid?
-      expect(item.errors[:postage_pay_id]).to include("can't be blank")
+      # item = build(:item, postage_pay_id: nil)
+      @item.postage_pay_id = nil
+      @item.valid?
+      expect(@item.errors[:postage_pay_id]).to include("can't be blank")
     end
 
     # shipping_area_idが空であれば登録できないこと
     it 'is invalid without a shipping_area_id' do
-      item = build(:item, shipping_area_id: nil)
-      item.valid?
-      expect(item.errors[:shipping_area_id]).to include("can't be blank")
+      # item = build(:item, shipping_area_id: nil)
+      @item.shipping_area_id = nil
+      @item.valid?
+      expect(@item.errors[:shipping_area_id]).to include("can't be blank")
     end
 
     # days_until_shipping_idが空であれば登録できないこと
     it 'is invalid without a days_until_shipping_id' do
-      item = build(:item, days_until_shipping_id: nil)
-      item.valid?
-      expect(item.errors[:days_until_shipping_id]).to include("can't be blank")
+      # item = build(:item, days_until_shipping_id: nil)
+      @item.days_until_shipping_id = nil
+
+      # binding.pry
+
+      @item.valid?
+      expect(@item.errors[:days_until_shipping_id]).to include("can't be blank")
+    end
+
+    # userが空であれば登録できないこと
+    it 'is invalid without a user_id' do
+      @item.user = nil
+
+      @item.valid?
+      expect(@item.errors[:user]).to include('must exist')
     end
 
     # priceの範囲が、¥300~¥9,999,999の間でなければ登録できること
     it 'is valid with the price range is between ¥300 and ¥9,999,999' do
-      item = build(:item, price: '1000')
-      expect(item).to be_valid
+      # item = build(:item, price: '1000')
+      @item.price = '1000'
+
+      # binding.pry
+
+      expect(@item).to be_valid
     end
 
     # priceの範囲が、¥300~¥9,999,999の間でなければ登録できないこと
     it 'is invalid without the price range is between ¥300 and ¥9,999,999' do
-      item = build(:item, price: '10')
-      item.valid?
-      expect(item.errors[:price]).to include('is not included in the list')
+      # item = build(:item, price: '10')
+      @item.price = '10'
+      @item.valid?
+      expect(@item.errors[:price]).to include('is not included in the list')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-
   describe '#create' do
     # 全てのカラムが存在すれば登録できること
     it 'is valid with all column' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -9,13 +9,11 @@ RSpec.describe Item, type: :model do
 
     # 全てのカラムが存在すれば登録できること
     it 'is valid with all column' do
-      # item = build(:item)
       expect(@item).to be_valid
     end
 
     # imageが空であれば登録できないこと
     it 'is invalid without a image' do
-      # item = build(:item)
       @item.image = nil
       @item.valid?
       expect(@item.errors[:image]).to include("can't be blank")
@@ -23,7 +21,6 @@ RSpec.describe Item, type: :model do
 
     # nameが空であれば登録できないこと
     it 'is invalid without a name' do
-      # item = build(:item, name: nil)
       @item.name = nil
       @item.valid?
       expect(@item.errors[:name]).to include("can't be blank")
@@ -31,7 +28,6 @@ RSpec.describe Item, type: :model do
 
     # introductionが空であれば登録できないこと
     it 'is invalid without a introduction' do
-      # item = build(:item, introduction: nil)
       @item.introduction = nil
       @item.valid?
       expect(@item.errors[:introduction]).to include("can't be blank")
@@ -39,7 +35,6 @@ RSpec.describe Item, type: :model do
 
     # priceが空であれば登録できないこと
     it 'is invalid without a price' do
-      # item = build(:item, price: nil)
       @item.price = nil
       @item.valid?
       expect(@item.errors[:price]).to include("can't be blank")
@@ -47,7 +42,6 @@ RSpec.describe Item, type: :model do
 
     # sales_commissionが空であれば登録できないこと
     it 'is invalid without a sales_commission' do
-      # item = build(:item, sales_commission: nil)
       @item.sales_commission = nil
       @item.valid?
       expect(@item.errors[:sales_commission]).to include("can't be blank")
@@ -55,7 +49,6 @@ RSpec.describe Item, type: :model do
 
     # sales_profitが空であれば登録できないこと
     it 'is invalid without a sales_profit' do
-      # item = build(:item, sales_profit: nil)
       @item.sales_profit = nil
       @item.valid?
       expect(@item.errors[:sales_profit]).to include("can't be blank")
@@ -63,7 +56,6 @@ RSpec.describe Item, type: :model do
 
     # category_idが空であれば登録できないこと
     it 'is invalid without a category_id' do
-      # item = build(:item, category_id: nil)
       @item.category_id = nil
       @item.valid?
       expect(@item.errors[:category_id]).to include("can't be blank")
@@ -71,7 +63,6 @@ RSpec.describe Item, type: :model do
 
     # status_idが空であれば登録できないこと
     it 'is invalid without a status_id' do
-      # item = build(:item, status_id: nil)
       @item.status_id = nil
       @item.valid?
       expect(@item.errors[:status_id]).to include("can't be blank")
@@ -79,7 +70,6 @@ RSpec.describe Item, type: :model do
 
     # postage_pay_idが空であれば登録できないこと
     it 'is invalid without a postage_pay_id' do
-      # item = build(:item, postage_pay_id: nil)
       @item.postage_pay_id = nil
       @item.valid?
       expect(@item.errors[:postage_pay_id]).to include("can't be blank")
@@ -87,7 +77,6 @@ RSpec.describe Item, type: :model do
 
     # shipping_area_idが空であれば登録できないこと
     it 'is invalid without a shipping_area_id' do
-      # item = build(:item, shipping_area_id: nil)
       @item.shipping_area_id = nil
       @item.valid?
       expect(@item.errors[:shipping_area_id]).to include("can't be blank")
@@ -95,11 +84,7 @@ RSpec.describe Item, type: :model do
 
     # days_until_shipping_idが空であれば登録できないこと
     it 'is invalid without a days_until_shipping_id' do
-      # item = build(:item, days_until_shipping_id: nil)
       @item.days_until_shipping_id = nil
-
-      # binding.pry
-
       @item.valid?
       expect(@item.errors[:days_until_shipping_id]).to include("can't be blank")
     end
@@ -107,24 +92,18 @@ RSpec.describe Item, type: :model do
     # userが空であれば登録できないこと
     it 'is invalid without a user_id' do
       @item.user = nil
-
       @item.valid?
       expect(@item.errors[:user]).to include('must exist')
     end
 
     # priceの範囲が、¥300~¥9,999,999の間でなければ登録できること
     it 'is valid with the price range is between ¥300 and ¥9,999,999' do
-      # item = build(:item, price: '1000')
       @item.price = '1000'
-
-      # binding.pry
-
       expect(@item).to be_valid
     end
 
     # priceの範囲が、¥300~¥9,999,999の間でなければ登録できないこと
     it 'is invalid without the price range is between ¥300 and ¥9,999,999' do
-      # item = build(:item, price: '10')
       @item.price = '10'
       @item.valid?
       expect(@item.errors[:price]).to include('is not included in the list')

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Purchase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/purchases_request_spec.rb
+++ b/spec/requests/purchases_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Purchases", type: :request do
-
+RSpec.describe 'Purchases', type: :request do
 end

--- a/spec/requests/purchases_request_spec.rb
+++ b/spec/requests/purchases_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Purchases", type: :request do
+
+end


### PR DESCRIPTION
#WHAT
商品詳細表示機能実装
- ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/a46591c8d452280ac94c09fa628fd173

- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/c7506d1bde3a919cf8d928abfd4f7383

- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/1c479c4927d5302b3c92d35372c73eb5

#WHY
- ユーザーが商品詳細情報を確認し、出品者は編集・削除、ログイン済み出品者以外は購入画面へ進めるよう分岐させるため。